### PR TITLE
CIP-0165: Update gov_committee namespapce, add entities_committee

### DIFF
--- a/CIP-0165/README.md
+++ b/CIP-0165/README.md
@@ -63,18 +63,19 @@ In order to provide types of the values and be able to store and verify only par
 
 Each logical table/type is a namespace identified by a canonical string (e.g., `"utxo"`, `"gov"`). Namespace identifiers are UTF-8 encoded; all comparisons and ordering use bytewise (lexicographic by Unicode codepoint) ordering on the UTF-8 byte representation.
 
-| Shortname           | Content                         |
-| ------------------- | ------------------------------- |
-| blocks/v0           | Blocks created                  |
-| gov/committee/v0    | Governance action state         |
-| gov/constitution/v0 | Constitution                    |
-| gov/pparams/v0      | Protocol parameters             |
-| gov/proposals/v0    | Update proposals                |
-| nonces/v0           | Nonces                          |
-| snapshots/mark/v0   | snapshots mark                  |
-| snapshots/set/v0    | snapshots set                   |
-| snapshots/go/v0     | snapshots go                    |
-| utxo/v0             | UTXOs                           |
+| Shortname             | Content                 |
+| --------------------- | ----------------------- |
+| blocks/v0             | Blocks created          |
+| entities/committee/v0 | Entities committee      |
+| gov/committee/v0      | Governance action state |
+| gov/constitution/v0   | Constitution            |
+| gov/pparams/v0        | Protocol parameters     |
+| gov/proposals/v0      | Update proposals        |
+| nonces/v0             | Nonces                  |
+| snapshots/mark/v0     | snapshots mark          |
+| snapshots/set/v0      | snapshots set           |
+| snapshots/go/v0       | snapshots go            |
+| utxo/v0               | UTXOs                   |
 
 New namespaces may and will be introduced in the future. With new eras and features, new types of the data will be introduced and stored. In order to define what data is stored in the SCLS file, tools fill the `MANIFEST` record and define namespaces. The order of the namespaces does not change the signatures and other integrity data.
 

--- a/CIP-0165/namespaces/README.md
+++ b/CIP-0165/namespaces/README.md
@@ -4,17 +4,18 @@ This is directory of the supported namespaces.
 
 Each namespace defines a non-intersecting slices of the data.
 
-| Shortname            | Content                         | Key size | Key description |
-| -------------------- | ------------------------------- | -------- | --------------- |
-| blocks/v0            | Blocks created                  | 36       | keyhash of the stake pool |
-| gov/committee/v0     | Governance action state         | 8        | epoch |
-| gov/constitution/v0  | Constitution                    | 8        | epoch |
-| gov/pparams/v0       | Protocol parameters             | 4        | current, previous, or future |
-| gov/proposals/v0     | Update proposals                | 34       | address of the proposal in transactions |
-| nonces/v0            | Nonces                          | 1        | zero key |
-| snapshots/mark/v0    | snapshots                       | 32       | key type, mark stage, value type (see docs) |
-| snapshots/set/v0     | snapshots                       | 32       | key type, set stage, value type (see docs) |
-| snapshots/go/v0      | snapshots                       | 32       | key type, go stage, value type (see docs) |
-| utxo/v0              | UTXOs                           | 34       | utxo address in the transaction |
+| Shortname             | Content                 | Key size | Key description                             |
+| --------------------- | ----------------------- | -------- | ------------------------------------------- |
+| blocks/v0             | Blocks created          | 36       | keyhash of the stake pool                   |
+| entities/committee/v0 | Entities committee      | 8        | epoch                                       |
+| gov/committee/v0      | Governance action state | 8        | epoch                                       |
+| gov/constitution/v0   | Constitution            | 8        | epoch                                       |
+| gov/pparams/v0        | Protocol parameters     | 4        | current, previous, or future                |
+| gov/proposals/v0      | Update proposals        | 34       | address of the proposal in transactions     |
+| nonces/v0             | Nonces                  | 1        | zero key                                    |
+| snapshots/mark/v0     | snapshots               | 32       | key type, mark stage, value type (see docs) |
+| snapshots/set/v0      | snapshots               | 32       | key type, set stage, value type (see docs)  |
+| snapshots/go/v0       | snapshots               | 32       | key type, go stage, value type (see docs)   |
+| utxo/v0               | UTXOs                   | 34       | utxo address in the transaction             |
 
 Key specifications are described in cddl specification comments.

--- a/CIP-0165/namespaces/entities_committee_v0.cddl
+++ b/CIP-0165/namespaces/entities_committee_v0.cddl
@@ -1,27 +1,27 @@
 ; This file was auto-generated from huddle.
-; Source: https://github.com/tweag/cardano-cls/blob/main/scls-cardano/cddl-src/Cardano/SCLS/Namespace/GovCommittee.hs
+; Source: https://github.com/tweag/cardano-cls/blob/main/scls-cardano/cddl-src/Cardano/SCLS/Namespace/EntitiesCommittee.hs
 
 ;  The key for the namespace
-;
+; 
 ;  ```
 ;  meta:
 ;    endian: be
-;
+; 
 ;  seq:
 ;    - id: key
-;      type: gov_committee
-;
+;      type: entities_committee
+; 
 ;  types:
-;    gov_committee:
+;    entities_committee:
 ;      seq:
 ;        - id: epoch
 ;          doc: epoch
 ;          type: u8
 ;  ```
-record_entry = committee/ nil
+record_entry = committee_state
 
-;  Storage of the committee members
-committee = [{* credential => epoch_no}, unit_interval]
+;  Storage of the committee state
+committee_state = {* credential => committee_authorization}
 
 credential = [0, addr_keyhash// 1, script_hash]
 
@@ -39,13 +39,13 @@ hash28 = bytes .size 28
 ;   - "\x03" for Plutus V3 scripts
 script_hash = hash28
 
-epoch_no = uint .size 8
+;  0 - hot committee member
+;  1 - resignation
+committee_authorization = [0, credential// 1, anchor/ nil]
 
-; NOTE: The real unit_interval is: #6.30([uint, uint])
 ; 
-;  A unit interval is a number in the range between 0 and 1, which
-;  means there are two extra constraints:
-;     1. numerator <= denominator
-;     2. denominator > 0
-unit_interval = 
-  #6.30([uint .le 18446744073709551615, uint .le 18446744073709551615])
+;  Signed url
+anchor = [anchor_url : url, anchor_data_hash : bytes]
+
+url = text .size (0 .. 128)
+


### PR DESCRIPTION
Introduce the `entities/committee/v0` namespace (with the previous definition of `gov/committee/v0`. Update the `gov_committee/v0` namespace to reflect the data from gov state.

---

- [ ] Depends on tweag/cardano-cls#267